### PR TITLE
Refactor follow seeding and improve profile error handling

### DIFF
--- a/src/config/dev/follows.ts
+++ b/src/config/dev/follows.ts
@@ -5,70 +5,70 @@
 export const follows = [
   // Admin folgt Erik und Caleb
   {
-    followerId: 'admin',
-    followedId: 'erik',
+    followerUsername: 'admin',
+    followedUsername: 'erik',
     createdAt: new Date('2025-07-22T09:00:00Z'),
     updatedAt: new Date('2025-07-22T09:00:00Z'),
   },
   {
-    followerId: 'admin',
-    followedId: 'caleb-script',
+    followerUsername: 'admin',
+    followedUsername: 'caleb-script',
     createdAt: new Date('2025-07-22T09:05:00Z'),
     updatedAt: new Date('2025-07-22T09:05:00Z'),
   },
 
   // Erik folgt Admin und Rae
   {
-    followerId: 'erik',
-    followedId: 'admin',
+    followerUsername: 'erik',
+    followedUsername: 'admin',
     createdAt: new Date('2025-07-22T09:10:00Z'),
     updatedAt: new Date('2025-07-22T09:10:00Z'),
   },
   {
-    followerId: 'erik',
-    followedId: 'rae',
+    followerUsername: 'erik',
+    followedUsername: 'rae',
     createdAt: new Date('2025-07-22T09:15:00Z'),
     updatedAt: new Date('2025-07-22T09:15:00Z'),
   },
 
   // Caleb folgt allen außer sich selbst
   {
-    followerId: 'caleb-script',
-    followedId: 'admin',
+    followerUsername: 'caleb-script',
+    followedUsername: 'admin',
     createdAt: new Date('2025-07-22T09:20:00Z'),
     updatedAt: new Date('2025-07-22T09:20:00Z'),
   },
   {
-    followerId: 'caleb-script',
-    followedId: 'erik',
+    followerUsername: 'caleb-script',
+    followedUsername: 'erik',
     createdAt: new Date('2025-07-22T09:25:00Z'),
     updatedAt: new Date('2025-07-22T09:25:00Z'),
   },
   {
-    followerId: 'caleb-script',
-    followedId: 'leroy135',
+    followerUsername: 'caleb-script',
+    followedUsername: 'leroy135',
     createdAt: new Date('2025-07-22T09:30:00Z'),
     updatedAt: new Date('2025-07-22T09:30:00Z'),
   },
   {
-    followerId: 'caleb-script',
-    followedId: 'rae',
+    followerUsername: 'caleb-script',
+    followedUsername: 'rae',
     createdAt: new Date('2025-07-22T09:35:00Z'),
     updatedAt: new Date('2025-07-22T09:35:00Z'),
   },
 
   // Leroy folgt Caleb
   {
-    followerId: 'leroy135',
-    followedId: 'caleb-script',
+    followerUsername: 'leroy135',
+    followedUsername: 'caleb-script',
     createdAt: new Date('2025-07-22T09:40:00Z'),
     updatedAt: new Date('2025-07-22T09:40:00Z'),
   },
 
   // Rae folgt Admin
   {
-    followerId: 'rae',
-    followedId: 'admin',
+    followerUsername: 'rae',
+    followedUsername: 'admin',
     createdAt: new Date('2025-07-22T09:45:00Z'),
     updatedAt: new Date('2025-07-22T09:45:00Z'),
   },

--- a/src/profile/resolver/profile-query.resolver.ts
+++ b/src/profile/resolver/profile-query.resolver.ts
@@ -75,7 +75,7 @@ export class ProfileQueryResolver {
 
     @Query(() => FullProfileDTO)
     @Public()
-    async getFullProfilByUserId(
+    async getFullProfileByUserId(
         @Args('customerId') customerId: UUID,
     ): Promise<FullProfile> {
         this.#logger.debug('getFullProfilByUserId: customerId: %s', customerId);

--- a/src/profile/service/follow-write.service.ts
+++ b/src/profile/service/follow-write.service.ts
@@ -11,7 +11,8 @@ export class FollowWriteService {
     this.#followModel = followModel;
   }
 
-  async followUser(followerId: string, followedId: string): Promise<boolean> {
+    async followUser(followerId: string, followedId: string): Promise<boolean> {
+
     const exists = await this.#followModel.findOne({ followerId, followedId });
     if (exists) return true;
     await this.#followModel.create({ followerId, followedId });


### PR DESCRIPTION
Refactored follow seeding to use followerUsername and followedUsername instead of followerId and followedId, and removed unnecessary existence checks. Improved error handling in ProfileReadService by throwing ApolloError when a profile is not found by userId, and added debug logging. Fixed a typo in getFullProfileByUserId resolver method name.
